### PR TITLE
:bug:(fix) issue due to extention method

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.6.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Lower dart version causing the below error
>This requires the 'extension-methods' experiment to be enabled.
>Try enabling this experiment by adding it to the command line when compiling and running.

By updating dart sdk issue is resolved.